### PR TITLE
ci: update bleep publish plugin and add publish mode in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: bleep-build/bleep-setup-action@0.0.2
       - name: Release
-        run: bleep --debug publish
+        run: bleep --debug publish -- --mode=portal-api:AUTOMATIC
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/bleep.yaml
+++ b/bleep.yaml
@@ -4,7 +4,7 @@ jvm:
   name: graalvm-java17:22.3.1
 projects:
   scripts:
-    dependencies: io.github.nafg.bleep-plugins::bleep-plugin-publish:0.0.5
+    dependencies: io.github.nafg.bleep-plugins::bleep-plugin-publish:0.4.0
     extends:
     - template-common
     - template-scala-3


### PR DESCRIPTION
Updated the bleep-plugin-publish dependency from version 0.0.5 to 0.4.0 in bleep.yaml to
use the latest plugin features and fixes. Modified the GitHub Actions CI workflow to add
'--mode=portal-api:AUTOMATIC' to the bleep publish command, enabling automatic mode for
portal-api during publishing. These changes improve the publishing process by leveraging
new plugin capabilities and specifying the publishing mode explicitly.
